### PR TITLE
feat(ci/cd): automatic build for leam frappe images

### DIFF
--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -38,7 +38,7 @@ jobs:
           org.opencontainers.image.vendor=leam-tech
         
         flavor: |
-          latest=false
+          latest=true
 
   
     - name: Image Tag output 
@@ -113,7 +113,7 @@ jobs:
           org.opencontainers.image.vendor=romman.io
         
         flavor: |
-          latest=false
+          latest=true
 
           
     

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -28,8 +28,9 @@ jobs:
         images: |
           registry.romman.io/leam-frappe-nginx
         # generate Docker tags based on the following events/attributes
+        # TODO: make sure the patch number here is always at 0
         tags: |
-          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}.{{minor}}.{{patch}}
           type=schedule,pattern={{date 'YYYYMMDD'}}
           
         labels: |
@@ -89,7 +90,7 @@ jobs:
     - name: Checkout frappe_docker repo
       uses: actions/checkout@v2
       with:
-        repository: leam-tech/frappe_docker #TODO: change yaacine to leam-tech
+        repository: leam-tech/frappe_docker 
         ref: leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
@@ -103,8 +104,9 @@ jobs:
           
           registry.romman.io/leam-frappe-worker
         # generate Docker tags based on the following events/attributes
+        # TODO: make sure the patch number here is always at 0
         tags: |
-          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}.{{minor}}.{{patch}}
           type=schedule,pattern={{date 'YYYYMMDD'}}
         
         labels: |

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         repository: leam-tech/frappe_docker
         ref: sync-leam-fork
-        token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
+        # token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 
     - name: Docker meta
@@ -69,8 +69,8 @@ jobs:
         push: true #${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        secrets: |
-          GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
+        # secrets: |
+        #   GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
 
     - name: Image digest
       run: |
@@ -92,7 +92,7 @@ jobs:
       with:
         repository: leam-tech/frappe_docker 
         ref: sync-leam-fork
-        token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
+        # token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 
     - name: Docker meta
@@ -147,8 +147,8 @@ jobs:
         push: true #${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        secrets: |
-          GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
+        # secrets: |
+        #   GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
     
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -1,0 +1,157 @@
+name: Docker Image CI For Leam Frappe (version-13-fixes)
+
+on:
+  push:
+    # branches: [ frappe-fork-cicd ]
+
+    tags:
+        - 'v*'
+jobs:
+  build-leam-frappe-nginx:
+    runs-on: ubuntu-20.04
+    steps:
+
+    # checkout the frappe docker repo in order to use it to build the images
+    - name: Checkout frappe_docker repo
+      uses: actions/checkout@v2
+      with:
+        repository: yaacine/frappe_docker  #TODO: change yaacine to leam-tech
+        ref: leam-fork
+        token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
+        
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          registry.romman.io/leam-frappe-nginx
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=semver,pattern={{version}}
+          type=schedule,pattern={{date 'YYYYMMDD'}}
+          type=semver,pattern={{major}}.{{minor}}.{{patch}}
+        labels: |
+          org.opencontainers.image.title=leam-frappe-nginx
+          org.opencontainers.image.description=nginx image for leam frappe 
+          org.opencontainers.image.vendor=leam-tech
+        
+        flavor: |
+          latest=false
+
+  
+    - name: Image Tag output 
+      run: |
+        echo ${{ steps.meta.outputs.tags }}
+
+        
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to self-hosted registry
+      uses: docker/login-action@v1 
+      with:
+        registry: registry.romman.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: build/frappe-nginx/Dockerfile
+        push: false #${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        secrets: |
+          GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
+
+    - name: Image digest
+      run: |
+        echo ${{ steps.docker_build.outputs.digest }}
+   
+   
+    # - name: Build the Docker image
+    #   run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+
+
+
+  build-leam-frappe-worker:
+    runs-on: ubuntu-20.04
+    steps:
+
+    # checkout the frappe docker repo in order to use it to build the images
+    - name: Checkout frappe_docker repo
+      uses: actions/checkout@v2
+      with:
+        repository: yaacine/frappe_docker #TODO: change yaacine to leam-tech
+        ref: leam-fork
+        token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
+        
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          
+          registry.romman.io/leam-frappe-worker
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=semver,pattern={{version}}
+          type=schedule,pattern={{date 'YYYYMMDD'}}
+          type=semver,pattern={{major}}.{{minor}}.{{patch}}
+        
+        labels: |
+          org.opencontainers.image.title=leam-frappe-worker
+          org.opencontainers.image.description=worker image for leam frappe 
+          org.opencontainers.image.vendor=romman.io
+        
+        flavor: |
+          latest=false
+
+          
+    
+    - name: Image Tag output 
+      run: |
+        echo ${{ steps.meta.outputs.tags }}
+        echo ${{ steps.meta.outputs.version }}
+
+        
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to self-hosted registry
+      uses: docker/login-action@v1 
+      with:
+        registry: registry.romman.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: build/frappe-nginx/Dockerfile
+        push: true #${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        secrets: |
+          GH_ACCESS_TOKEN=${{ secrets.MY_GIT_AUTH_TOKEN }}
+    
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}
+   
+   
+    # - name: Build the Docker image
+    #   run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -31,7 +31,7 @@ jobs:
         tags: |
           type=semver,pattern={{version}}
           type=schedule,pattern={{date 'YYYYMMDD'}}
-          type=semver,pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,pattern={{major}}.{{minor}}
         labels: |
           org.opencontainers.image.title=leam-frappe-nginx
           org.opencontainers.image.description=nginx image for leam frappe 
@@ -106,7 +106,7 @@ jobs:
         tags: |
           type=semver,pattern={{version}}
           type=schedule,pattern={{date 'YYYYMMDD'}}
-          type=semver,pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,pattern={{major}}.{{minor}}
         
         labels: |
           org.opencontainers.image.title=leam-frappe-worker

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: yaacine/frappe_docker  #TODO: change yaacine to leam-tech
-        ref: leam-fork
+        ref: sync-leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -65,7 +65,7 @@ jobs:
       with:
         context: .
         file: build/frappe-nginx/Dockerfile
-        push: false #${{ github.event_name != 'pull_request' }}
+        push: true #${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         secrets: |

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -29,9 +29,9 @@ jobs:
           registry.romman.io/leam-frappe-nginx
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=semver,pattern={{version}}
-          type=schedule,pattern={{date 'YYYYMMDD'}}
           type=semver,pattern={{major}}.{{minor}}
+          type=schedule,pattern={{date 'YYYYMMDD'}}
+          
         labels: |
           org.opencontainers.image.title=leam-frappe-nginx
           org.opencontainers.image.description=nginx image for leam frappe 
@@ -104,9 +104,8 @@ jobs:
           registry.romman.io/leam-frappe-worker
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=semver,pattern={{version}}
-          type=schedule,pattern={{date 'YYYYMMDD'}}
           type=semver,pattern={{major}}.{{minor}}
+          type=schedule,pattern={{date 'YYYYMMDD'}}
         
         labels: |
           org.opencontainers.image.title=leam-frappe-worker

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -143,7 +143,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: build/frappe-nginx/Dockerfile
+        file: build/frappe-worker/Dockerfile
         push: true #${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: leam-tech/frappe_docker
-        ref: leam-fork
+        ref: sync-leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 
@@ -91,7 +91,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: leam-tech/frappe_docker 
-        ref: leam-fork
+        ref: sync-leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -15,8 +15,8 @@ jobs:
     - name: Checkout frappe_docker repo
       uses: actions/checkout@v2
       with:
-        repository: yaacine/frappe_docker  #TODO: change yaacine to leam-tech
-        ref: sync-leam-fork
+        repository: leam-tech/frappe_docker
+        ref: leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         
 
@@ -89,7 +89,7 @@ jobs:
     - name: Checkout frappe_docker repo
       uses: actions/checkout@v2
       with:
-        repository: yaacine/frappe_docker #TODO: change yaacine to leam-tech
+        repository: leam-tech/frappe_docker #TODO: change yaacine to leam-tech
         ref: leam-fork
         token: ${{ secrets.MY_GIT_AUTH_TOKEN }} # `GH_PAT` is a secret that contains your PAT
         

--- a/.github/workflows/build_leam_frappe_images.yaml
+++ b/.github/workflows/build_leam_frappe_images.yaml
@@ -38,7 +38,7 @@ jobs:
           org.opencontainers.image.vendor=leam-tech
         
         flavor: |
-          latest=true
+          latest=false
 
   
     - name: Image Tag output 
@@ -113,7 +113,7 @@ jobs:
           org.opencontainers.image.vendor=romman.io
         
         flavor: |
-          latest=true
+          latest=false
 
           
     


### PR DESCRIPTION
It automates the build of `leam-frappe-nginx` and `leam-frappe-worker` images and pushes them to the our private registry.

### How it works
In order to trigger the workflows, you need to perform those steps:

- make sure your github repo defines the following secrets:
1. **DOCKER_USERNAME** : The username of your docker registry
2. **DOCKER_TOKEN** : The password of your docker registry

- make sure all your changes are committed
- create a git tag for your last commit using `git tag -a vX.Y.Z -m "your tag message" ` (for consistency, it's recommended that X (major) is the same with frappe versions, `example 13`
- push your tag to the remote repo with `git push upstream vX.Y.Z`. PS: Change "upstream" with the appropriate remote name, you can get it with `git remote -v`
- this will trigger the workflow and build the image that will be tagged with X.Y.0  (notice that we are not using the patch number. example `leam-frappe-nginx:13.5.0`)
